### PR TITLE
add fetch_categories and update_preferences to Magicbell::Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 # Magicbell::Rails
 
-Wrapper around magicbell api to deliver notifications to your users in a background job
+Wrapper around magicbell api to:
+- deliver notifications to your users in a background job
+- fetch categories
+- update notification preferences
 
 ## Installation
 
@@ -59,6 +62,21 @@ Magicbell::Rails.bell(
     }
   }
 ).deliver_later
+```
+
+```ruby
+# Gets all categories that have been created
+Magicbell::Rails.fetch_categories(external_id)
+
+# Updates notification preferences given a payload
+payload = { 'notification_preferences' => {
+              'categories' => [
+                { 'slug' => 'stay_in_touch', 'channels' => [{ 'slug' => 'email', 'enabled' => false }] },
+                { 'slug' => 'list_shared', 'channels' => [{ 'slug' => 'email', 'enabled' => false }] }
+              ]
+            }
+          }.to_json
+Magicbell::Rails.update_notification_preferences(external_id, payload)
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Magicbell::Rails.bell(
 
 ```ruby
 # Gets all categories that have been created
-Magicbell::Rails.fetch_categories(external_id)
+Magicbell::Rails.fetch_categories(external_id:)
 
 # Updates notification preferences given a payload
 payload = { 'notification_preferences' => {
@@ -76,7 +76,7 @@ payload = { 'notification_preferences' => {
               ]
             }
           }.to_json
-Magicbell::Rails.update_notification_preferences(external_id, payload)
+Magicbell::Rails.update_notification_preferences(external_id:, payload:)
 ```
 
 ## Contributing

--- a/app/models/magicbell/rails/notification_preference.rb
+++ b/app/models/magicbell/rails/notification_preference.rb
@@ -1,0 +1,9 @@
+module Magicbell
+  module Rails
+    module NotificationPreference
+      def self.update(external_id:, payload:)
+        Magicbell::Rails.client.user_with_external_id(external_id).notification_preferences.update(payload)
+      end
+    end
+  end
+end

--- a/app/models/magicbell/rails/user_category.rb
+++ b/app/models/magicbell/rails/user_category.rb
@@ -9,14 +9,14 @@ module Magicbell
         response = Magicbell::Rails.client.user_with_external_id(external_id)
                                    .notification_preferences.retrieve.attributes
 
-        response['categories']&.map do |category|
+        Array(response['categories']).map do |category|
           UserCategory.new(
             slug: category['slug'], label: category['label'],
             channels: category['channels'].map do |channel|
               Channel.new(slug: channel['slug'], label: channel['label'], enabled: channel['enabled'])
             end
           )
-        end || []
+        end
       end
     end
   end

--- a/app/models/magicbell/rails/user_category.rb
+++ b/app/models/magicbell/rails/user_category.rb
@@ -1,0 +1,23 @@
+module Magicbell
+  module Rails
+    module UserCategory
+      UserCategory = Struct.new(:slug, :label, :channels, keyword_init: true)
+      Channel = Struct.new(:slug, :label, :enabled, keyword_init: true)
+
+      # Fetches all categories for a user
+      def self.fetch(external_id:)
+        response = Magicbell::Rails.client.user_with_external_id(external_id)
+                                   .notification_preferences.retrieve.attributes
+
+        response['categories']&.map do |category|
+          UserCategory.new(
+            slug: category['slug'], label: category['label'],
+            channels: category['channels'].map do |channel|
+              Channel.new(slug: channel['slug'], label: channel['label'], enabled: channel['enabled'])
+            end
+          )
+        end || []
+      end
+    end
+  end
+end

--- a/lib/magicbell-rails.rb
+++ b/lib/magicbell-rails.rb
@@ -11,5 +11,22 @@ module Magicbell
     def self.bell(args)
       Notification.bell(args)
     end
+
+    def self.fetch_categories(external_id)
+      response = client.user_with_external_id(external_id).notification_preferences.retrieve.attributes
+
+      response['categories']&.map { |category| category['slug'] } || []
+    end
+
+    def self.update_notification_preferences(external_id, payload)
+      client.user_with_external_id(external_id).notification_preferences.update(payload)
+    end
+
+    def self.client
+      MagicBell::Client.new(
+        api_key: Magicbell::Rails.api_key,
+        api_secret: Magicbell::Rails.api_secret
+      )
+    end
   end
 end

--- a/lib/magicbell-rails.rb
+++ b/lib/magicbell-rails.rb
@@ -12,14 +12,12 @@ module Magicbell
       Notification.bell(args)
     end
 
-    def self.fetch_categories(external_id)
-      response = client.user_with_external_id(external_id).notification_preferences.retrieve.attributes
-
-      response['categories']&.map { |category| category['slug'] } || []
+    def self.fetch_categories(external_id:)
+      UserCategory.fetch(external_id:)
     end
 
-    def self.update_notification_preferences(external_id, payload)
-      client.user_with_external_id(external_id).notification_preferences.update(payload)
+    def self.update_notification_preferences(external_id:, payload:)
+      NotificationPreference.update(external_id:, payload: payload)
     end
 
     def self.client

--- a/magicbell-rails.gemspec
+++ b/magicbell-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'magicbell-rails'
-  spec.version     = '0.2.1'
+  spec.version     = '0.3.0'
   spec.authors     = ['Grant Petersen-Speelman']
   spec.email       = ['grant@nexl.io']
   spec.homepage    = 'https://github.com/NEXL-LTS/nexl360/local_gems/magicbell-rails'

--- a/magicbell-rails.gemspec
+++ b/magicbell-rails.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |spec|
   spec.name        = 'magicbell-rails'
   spec.version     = '0.3.0'
-  spec.authors     = ['Grant Petersen-Speelman']
-  spec.email       = ['grant@nexl.io']
+  spec.authors     = ['Grant Petersen-Speelman', 'Connor Moot']
+  spec.email       = ['grant@nexl.io', 'connor@nexl.io']
   spec.homepage    = 'https://github.com/NEXL-LTS/nexl360/local_gems/magicbell-rails'
   spec.summary     = 'Rails wrapper gem for magicbell'
   spec.description = 'Rails wrapper gem for magicbell'

--- a/magicbell-rails.gemspec
+++ b/magicbell-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'magicbell-rails'
-  spec.version     = '0.2.0'
+  spec.version     = '0.2.1'
   spec.authors     = ['Grant Petersen-Speelman']
   spec.email       = ['grant@nexl.io']
   spec.homepage    = 'https://github.com/NEXL-LTS/nexl360/local_gems/magicbell-rails'

--- a/spec/magicbell-rails_spec.rb
+++ b/spec/magicbell-rails_spec.rb
@@ -11,6 +11,8 @@ module Magicbell
         described_class.api_secret = ENV.fetch('MAGICBELL_API_SECRET', 'SET_YOUR_API_SECRET')
       end
 
+      let!(:external_id) { 'nexl-360-latest.nexl.cloud/455' }
+
       describe 'end to end test' do
         it do
           VCR.use_cassette('e2e') do
@@ -31,61 +33,43 @@ module Magicbell
         end
       end
 
-      describe 'fetch and updates' do
-        let(:client) { instance_double(MagicBell::Client) }
-        let(:user) { instance_double(MagicBell::User) }
-        let(:notification_preferences) { instance_double(MagicBell::UserNotificationPreferences) }
-        let(:external_id) { 'test-user' }
-        let(:categories_response) do
+      describe '#fetch_categories' do
+        it 'fetches categories from MagicBell' do
+          VCR.use_cassette('fetch_categories') do
+            categories = described_class.fetch_categories(external_id)
+            expect(categories).to be_an(Array)
+            expect(categories).to include('StayInTouchReminder', 'FollowUpReminder')
+          end
+        end
+
+        context 'when there are no categories' do
+          it 'returns an empty array' do
+            VCR.use_cassette('fetch_no_categories') do
+              categories = described_class.fetch_categories('non-existent-external-id')
+              expect(categories).to eq([])
+            end
+          end
+        end
+      end
+
+      describe '#update_notification_preferences' do
+        let(:payload) do
           {
-            'categories' => [
-              { 'slug' => 'stay_in_touch' },
-              { 'slug' => 'list_shared' }
-            ]
+            notification_preferences: {
+              'categories' => [
+                {
+                  'slug' => 'StayInTouchReminder',
+                  'channels' => [{ 'slug' => 'email', 'enabled' => false }]
+                }
+              ]
+            }
           }
         end
 
-        before do
-          allow(MagicBell::Client).to receive(:new).and_return(client)
-          allow(client).to receive(:user_with_external_id).with(external_id).and_return(user)
-          allow(user).to receive(:notification_preferences).and_return(notification_preferences)
-          allow(notification_preferences).to receive(:update)
-          allow(client).to receive(:create_notification).and_return(true)
-        end
-
-        describe '#fetch_categories' do
-          it 'returns category slugs when categories exist' do
-            allow(notification_preferences).to receive(:retrieve).and_return(
-              instance_double(MagicBell::UserNotificationPreferences,
-                              attributes: categories_response)
-            )
-
-            expect(described_class.fetch_categories(external_id)).to match_array(%w[stay_in_touch
-                                                                                    list_shared])
-          end
-
-          it 'returns an empty array when no categories exist' do
-            allow(notification_preferences).to receive(:retrieve).and_return(
-              instance_double(MagicBell::UserNotificationPreferences,
-                              attributes: {})
-            )
-            expect(described_class.fetch_categories(external_id)).to eq([])
-          end
-        end
-
-        describe '#update_notification_preferences' do
-          let(:payload) do
-            {
-              'categories' => [
-                { 'slug' => 'stay_in_touch', 'channels' => [{ 'slug' => 'email', 'enabled' => false }] }
-              ]
-            }
-          end
-
-          it 'sends an update request with the correct payload' do
-            described_class.update_notification_preferences(external_id, payload)
-
-            expect(notification_preferences).to have_received(:update).with(payload)
+        it 'updates notification preferences on MagicBell' do
+          VCR.use_cassette('update_notification_preferences') do
+            expect { described_class.update_notification_preferences(external_id, payload) }
+              .not_to raise_error
           end
         end
       end

--- a/spec/magicbell-rails_spec.rb
+++ b/spec/magicbell-rails_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper' # rubocop:disable Naming/FileName
+require 'magicbell'
 
 module Magicbell
   module Rails
@@ -27,6 +28,65 @@ module Magicbell
 
           expect(Notification.count).to eq(1)
           expect(Result.count).to eq(1)
+        end
+      end
+
+      describe 'fetch and updates' do
+        let(:client) { instance_double(MagicBell::Client) }
+        let(:user) { instance_double(MagicBell::User) }
+        let(:notification_preferences) { instance_double(MagicBell::UserNotificationPreferences) }
+        let(:external_id) { 'test-user' }
+        let(:categories_response) do
+          {
+            'categories' => [
+              { 'slug' => 'stay_in_touch' },
+              { 'slug' => 'list_shared' }
+            ]
+          }
+        end
+
+        before do
+          allow(MagicBell::Client).to receive(:new).and_return(client)
+          allow(client).to receive(:user_with_external_id).with(external_id).and_return(user)
+          allow(user).to receive(:notification_preferences).and_return(notification_preferences)
+          allow(notification_preferences).to receive(:update)
+          allow(client).to receive(:create_notification).and_return(true)
+        end
+
+        describe '#fetch_categories' do
+          it 'returns category slugs when categories exist' do
+            allow(notification_preferences).to receive(:retrieve).and_return(
+              instance_double(MagicBell::UserNotificationPreferences,
+                              attributes: categories_response)
+            )
+
+            expect(described_class.fetch_categories(external_id)).to match_array(%w[stay_in_touch
+                                                                                    list_shared])
+          end
+
+          it 'returns an empty array when no categories exist' do
+            allow(notification_preferences).to receive(:retrieve).and_return(
+              instance_double(MagicBell::UserNotificationPreferences,
+                              attributes: {})
+            )
+            expect(described_class.fetch_categories(external_id)).to eq([])
+          end
+        end
+
+        describe '#update_notification_preferences' do
+          let(:payload) do
+            {
+              'categories' => [
+                { 'slug' => 'stay_in_touch', 'channels' => [{ 'slug' => 'email', 'enabled' => false }] }
+              ]
+            }
+          end
+
+          it 'sends an update request with the correct payload' do
+            described_class.update_notification_preferences(external_id, payload)
+
+            expect(notification_preferences).to have_received(:update).with(payload)
+          end
         end
       end
     end

--- a/spec/magicbell-rails_spec.rb
+++ b/spec/magicbell-rails_spec.rb
@@ -12,6 +12,18 @@ module Magicbell
       end
 
       let!(:external_id) { 'nexl-360-latest.nexl.cloud/455' }
+      let!(:email_channel) do
+        UserCategory::Channel.new(slug: 'email', label: 'Email', enabled: true)
+      end
+      let!(:stay_in_touch_category) do
+        UserCategory::UserCategory.new(slug: 'StayInTouchReminder', label: 'Stay in Touch',
+                                       channels: [email_channel])
+      end
+
+      let!(:follow_up_category) do
+        UserCategory::UserCategory.new(slug: 'FollowUpReminder', label: 'Opportunity Follow Up Reminder',
+                                       channels: [email_channel])
+      end
 
       describe 'end to end test' do
         it do
@@ -36,16 +48,16 @@ module Magicbell
       describe '#fetch_categories' do
         it 'fetches categories from MagicBell' do
           VCR.use_cassette('fetch_categories') do
-            categories = described_class.fetch_categories(external_id)
+            categories = described_class.fetch_categories(external_id:)
             expect(categories).to be_an(Array)
-            expect(categories).to include('StayInTouchReminder', 'FollowUpReminder')
+            expect(categories).to include(stay_in_touch_category, follow_up_category)
           end
         end
 
         context 'when there are no categories' do
           it 'returns an empty array' do
             VCR.use_cassette('fetch_no_categories') do
-              categories = described_class.fetch_categories('non-existent-external-id')
+              categories = described_class.fetch_categories(external_id: 'non-existent-external-id')
               expect(categories).to eq([])
             end
           end
@@ -68,7 +80,7 @@ module Magicbell
 
         it 'updates notification preferences on MagicBell' do
           VCR.use_cassette('update_notification_preferences') do
-            expect { described_class.update_notification_preferences(external_id, payload) }
+            expect { described_class.update_notification_preferences(external_id:, payload:) }
               .not_to raise_error
           end
         end

--- a/spec/vcr_cassettes/fetch_categories.yml
+++ b/spec/vcr_cassettes/fetch_categories.yml
@@ -1,0 +1,103 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.magicbell.io/notification_preferences
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Magicbell-Api-Key:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      X-Magicbell-Api-Secret:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      X-Magicbell-User-External-Id:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 14 Feb 2025 00:40:02 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Amzn-Trace-Id:
+      - Root=1-67ae90e1-3b405a5d6feae72454a25552;Parent=7a2bbcd1db3aa2cc;Sampled=0;Lineage=1:a1dcffa6:0
+      Access-Control-Max-Age:
+      - '86400'
+      X-Amzn-Requestid:
+      - aec240b9-a346-45d7-8786-a220557b0790
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Vary:
+      - accept-encoding
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e3f515cf2b40cd90e36f3532dbd8a5ae.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SYD3-P1
+      X-Amz-Cf-Id:
+      - m76eLasulJy8YLLLncNsNgQeivnUd8mcxDTGPVZvHZtfpzq2Cgn67g==
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=1hnxRV8h7teP8Qzre%2FIv9mOxaLh%2FaF%2F99XhnGhZv6xNtYLH3v0FCAfOSLmHEnhGzC3M1koUXBBgmjVFBmRz3vq2ypR8pNN%2BGeOY566ZvU1BgvufkFB7aTYVILl0zFR7GOHk%3D"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 911901205f02a979-SYD
+      Server-Timing:
+      - cfL4;desc="?proto=TCP&rtt=9912&min_rtt=9429&rtt_var=3881&sent=4&recv=6&lost=0&retrans=0&sent_bytes=2797&recv_bytes=1004&delivery_rate=307137&cwnd=251&unsent_bytes=0&cid=e037202a538dc197&ts=934&x=0"
+    body:
+      encoding: ASCII-8BIT
+      string: '
+      {
+        "notification_preferences": {
+          "categories": [
+            {
+              "slug": "StayInTouchReminder",
+              "label": "Stay in Touch",
+              "channels": [
+                { "slug": "in_app", "label": "In App", "enabled": true },
+                { "slug": "mobile_push", "label": "Mobile Push", "enabled": true },
+                { "slug": "web_push", "label": "Web Push", "enabled": true },
+                { "slug": "email", "label": "Email", "enabled": true }
+              ]
+            },
+            {
+              "slug": "FollowUpReminder",
+              "label": "Opportunity Follow Up Reminder",
+              "channels": [
+                { "slug": "in_app", "label": "In App", "enabled": true },
+                { "slug": "mobile_push", "label": "Mobile Push", "enabled": true },
+                { "slug": "web_push", "label": "Web Push", "enabled": true },
+                { "slug": "email", "label": "Email", "enabled": true }
+              ]
+            }
+          ]
+        }
+      }
+
+        '
+  recorded_at: Fri, 14 Feb 2025 00:40:02 GMT
+recorded_with: VCR 6.3.1

--- a/spec/vcr_cassettes/fetch_categories.yml
+++ b/spec/vcr_cassettes/fetch_categories.yml
@@ -78,9 +78,6 @@ http_interactions:
               "slug": "StayInTouchReminder",
               "label": "Stay in Touch",
               "channels": [
-                { "slug": "in_app", "label": "In App", "enabled": true },
-                { "slug": "mobile_push", "label": "Mobile Push", "enabled": true },
-                { "slug": "web_push", "label": "Web Push", "enabled": true },
                 { "slug": "email", "label": "Email", "enabled": true }
               ]
             },
@@ -88,9 +85,6 @@ http_interactions:
               "slug": "FollowUpReminder",
               "label": "Opportunity Follow Up Reminder",
               "channels": [
-                { "slug": "in_app", "label": "In App", "enabled": true },
-                { "slug": "mobile_push", "label": "Mobile Push", "enabled": true },
-                { "slug": "web_push", "label": "Web Push", "enabled": true },
                 { "slug": "email", "label": "Email", "enabled": true }
               ]
             }

--- a/spec/vcr_cassettes/fetch_empty_categories.yml
+++ b/spec/vcr_cassettes/fetch_empty_categories.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.magicbell.io/notification_preferences
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Magicbell-Api-Key:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      X-Magicbell-Api-Secret:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      X-Magicbell-User-External-Id:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 14 Feb 2025 00:40:02 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Amzn-Trace-Id:
+      - Root=1-67ae90e1-3b405a5d6feae72454a25552;Parent=7a2bbcd1db3aa2cc;Sampled=0;Lineage=1:a1dcffa6:0
+      Access-Control-Max-Age:
+      - '86400'
+      X-Amzn-Requestid:
+      - aec240b9-a346-45d7-8786-a220557b0790
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Vary:
+      - accept-encoding
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e3f515cf2b40cd90e36f3532dbd8a5ae.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SYD3-P1
+      X-Amz-Cf-Id:
+      - m76eLasulJy8YLLLncNsNgQeivnUd8mcxDTGPVZvHZtfpzq2Cgn67g==
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=1hnxRV8h7teP8Qzre%2FIv9mOxaLh%2FaF%2F99XhnGhZv6xNtYLH3v0FCAfOSLmHEnhGzC3M1koUXBBgmjVFBmRz3vq2ypR8pNN%2BGeOY566ZvU1BgvufkFB7aTYVILl0zFR7GOHk%3D"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 911901205f02a979-SYD
+      Server-Timing:
+      - cfL4;desc="?proto=TCP&rtt=9912&min_rtt=9429&rtt_var=3881&sent=4&recv=6&lost=0&retrans=0&sent_bytes=2797&recv_bytes=1004&delivery_rate=307137&cwnd=251&unsent_bytes=0&cid=e037202a538dc197&ts=934&x=0"
+    body:
+      encoding: ASCII-8BIT
+      string: '
+      {
+        "notification_preferences": {
+          "categories": []
+        }
+      }
+        '
+  recorded_at: Fri, 14 Feb 2025 00:40:02 GMT
+recorded_with: VCR 6.3.1

--- a/spec/vcr_cassettes/fetch_no_categories.yml
+++ b/spec/vcr_cassettes/fetch_no_categories.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.magicbell.io/notification_preferences
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Magicbell-Api-Key:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      X-Magicbell-Api-Secret:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      X-Magicbell-User-External-Id:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 14 Feb 2025 00:40:02 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Amzn-Trace-Id:
+      - Root=1-67ae90e1-3b405a5d6feae72454a25552;Parent=7a2bbcd1db3aa2cc;Sampled=0;Lineage=1:a1dcffa6:0
+      Access-Control-Max-Age:
+      - '86400'
+      X-Amzn-Requestid:
+      - aec240b9-a346-45d7-8786-a220557b0790
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Vary:
+      - accept-encoding
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e3f515cf2b40cd90e36f3532dbd8a5ae.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SYD3-P1
+      X-Amz-Cf-Id:
+      - m76eLasulJy8YLLLncNsNgQeivnUd8mcxDTGPVZvHZtfpzq2Cgn67g==
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=1hnxRV8h7teP8Qzre%2FIv9mOxaLh%2FaF%2F99XhnGhZv6xNtYLH3v0FCAfOSLmHEnhGzC3M1koUXBBgmjVFBmRz3vq2ypR8pNN%2BGeOY566ZvU1BgvufkFB7aTYVILl0zFR7GOHk%3D"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 911901205f02a979-SYD
+      Server-Timing:
+      - cfL4;desc="?proto=TCP&rtt=9912&min_rtt=9429&rtt_var=3881&sent=4&recv=6&lost=0&retrans=0&sent_bytes=2797&recv_bytes=1004&delivery_rate=307137&cwnd=251&unsent_bytes=0&cid=e037202a538dc197&ts=934&x=0"
+    body:
+      encoding: ASCII-8BIT
+      string: '
+      {
+        "notification_preferences": {
+        }
+      }
+        '
+  recorded_at: Fri, 14 Feb 2025 00:40:02 GMT
+recorded_with: VCR 6.3.1

--- a/spec/vcr_cassettes/update_notification_preferences.yml
+++ b/spec/vcr_cassettes/update_notification_preferences.yml
@@ -1,0 +1,134 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://api.magicbell.io/notification_preferences
+    body:
+      encoding: UTF-8
+      string: '{"notification_preferences":{"categories":[{"slug":"StayInTouchReminder","channels":[{"slug":"email","enabled":false}]}]}}'
+    headers:
+      X-Magicbell-Api-Key:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      X-Magicbell-Api-Secret:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      X-Magicbell-User-External-Id:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 14 Feb 2025 00:50:10 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Max-Age:
+      - '86400'
+      X-Amzn-Remapped-Date:
+      - Fri, 14 Feb 2025 00:50:09 GMT
+      X-Amzn-Requestid:
+      - 82f768eb-cf37-42b0-b0a3-e18732daa17c
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Runtime:
+      - '1.006195'
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Frame-Options:
+      - SAMEORIGIN
+      Access-Control-Allow-Headers:
+      - "*"
+      X-Amzn-Remapped-Content-Length:
+      - '4352'
+      X-Download-Options:
+      - noopen
+      X-Request-Id:
+      - 5f2d2076-1b7d-4e73-9c74-18aff8282738
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Access-Control-Allow-Methods:
+      - "*"
+      X-Amzn-Trace-Id:
+      - Root=1-67ae9340-3df889fd359e74af3997446d;Parent=7b2fae773c663b3f;Sampled=0;Lineage=1:a1dcffa6:0
+      Etag:
+      - W/"411fd99251cb98b43055086d2b99b549"
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 43b4a9a8792e30ac49642ef84dd35fc8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SYD3-P1
+      X-Amz-Cf-Id:
+      - D5dpL1Zpm-uddK8ccuz5JtvR5lbvJ2ti57OGBWZAqSL-yW22zDD0fg==
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=LTo3CJhI5Um4CKF01NPkeQbpD6hC7aBy21Z3XZUz8v2g%2BojOgBRpxF7%2BIatywOJdIIitimuPvQ5GlathjiQx4ClaBgbNihjhKS08ytmObX%2FJNpVXrq46OXOKwP580cULvaI%3D"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 91190ff16f8be7ec-SYD
+      Server-Timing:
+      - cfL4;desc="?proto=TCP&rtt=6194&min_rtt=4949&rtt_var=3551&sent=4&recv=8&lost=0&retrans=0&sent_bytes=2797&recv_bytes=1169&delivery_rate=282096&cwnd=251&unsent_bytes=0&cid=9a2139af7202f43c&ts=1844&x=0"
+    body:
+      encoding: ASCII-8BIT
+      string: '{"notification_preferences":{"categories":[{"label":"Task Assigned","slug":"AssignedTask","channels":[{"label":"In
+        app","slug":"in_app","enabled":true},{"label":"Mobile push","slug":"mobile_push","enabled":true},{"label":"Web
+        push","slug":"web_push","enabled":true},{"label":"Email","slug":"email","enabled":true}]},{"label":"Comment
+        Added","slug":"CommentAdded","channels":[{"label":"In app","slug":"in_app","enabled":true},{"label":"Mobile
+        push","slug":"mobile_push","enabled":true},{"label":"Web push","slug":"web_push","enabled":true},{"label":"Email","slug":"email","enabled":true}]},{"label":"Comment
+        Mentioned","slug":"CommentMentioned","channels":[{"label":"In app","slug":"in_app","enabled":true},{"label":"Mobile
+        push","slug":"mobile_push","enabled":true},{"label":"Web push","slug":"web_push","enabled":true},{"label":"Email","slug":"email","enabled":true}]},{"label":"Create
+        Activity Reminder","slug":"CreateActivityReminder","channels":[{"label":"In
+        app","slug":"in_app","enabled":true},{"label":"Mobile push","slug":"mobile_push","enabled":true},{"label":"Web
+        push","slug":"web_push","enabled":true},{"label":"Email","slug":"email","enabled":true}]},{"label":"Delegated
+        Task Completed","slug":"DelegatedTaskCompleted","channels":[{"label":"In app","slug":"in_app","enabled":true},{"label":"Mobile
+        push","slug":"mobile_push","enabled":true},{"label":"Web push","slug":"web_push","enabled":true},{"label":"Email","slug":"email","enabled":true}]},{"label":"Delegated
+        Task Reopened","slug":"DelegatedTaskReopened","channels":[{"label":"In app","slug":"in_app","enabled":true},{"label":"Mobile
+        push","slug":"mobile_push","enabled":true},{"label":"Web push","slug":"web_push","enabled":true},{"label":"Email","slug":"email","enabled":true}]},{"label":"Opportunity
+        Follow Up Reminder","slug":"FollowUpReminder","channels":[{"label":"In app","slug":"in_app","enabled":true},{"label":"Mobile
+        push","slug":"mobile_push","enabled":true},{"label":"Web push","slug":"web_push","enabled":true},{"label":"Email","slug":"email","enabled":true}]},{"label":"List
+        Shared","slug":"ListShared","channels":[{"label":"In app","slug":"in_app","enabled":true},{"label":"Mobile
+        push","slug":"mobile_push","enabled":true},{"label":"Web push","slug":"web_push","enabled":true},{"label":"Email","slug":"email","enabled":true}]},{"label":"New
+        Workspace Membership","slug":"NewProjectMembership","channels":[{"label":"In
+        app","slug":"in_app","enabled":true},{"label":"Mobile push","slug":"mobile_push","enabled":true},{"label":"Web
+        push","slug":"web_push","enabled":true},{"label":"Email","slug":"email","enabled":true}]},{"label":"Opportunity
+        Status Updated","slug":"OpportunityStatusChanged","channels":[{"label":"In
+        app","slug":"in_app","enabled":true},{"label":"Mobile push","slug":"mobile_push","enabled":true},{"label":"Web
+        push","slug":"web_push","enabled":true},{"label":"Email","slug":"email","enabled":true}]},{"label":"List
+        View Shared","slug":"SharedListView","channels":[{"label":"In app","slug":"in_app","enabled":true},{"label":"Mobile
+        push","slug":"mobile_push","enabled":true},{"label":"Web push","slug":"web_push","enabled":true},{"label":"Email","slug":"email","enabled":true}]},{"label":"Stay
+        In Touch Batched Reminder","slug":"StayInTouchBatchedReminder","channels":[{"label":"In
+        app","slug":"in_app","enabled":true},{"label":"Mobile push","slug":"mobile_push","enabled":true},{"label":"Web
+        push","slug":"web_push","enabled":true},{"label":"Email","slug":"email","enabled":true}]},{"label":"Stay
+        in Touch","slug":"StayInTouchReminder","channels":[{"label":"In app","slug":"in_app","enabled":true},{"label":"Mobile
+        push","slug":"mobile_push","enabled":true},{"label":"Web push","slug":"web_push","enabled":true},{"label":"Email","slug":"email","enabled":false}]},{"label":"Upcoming
+        Meeting Reminder","slug":"UpcomingMeetingReminder","channels":[{"label":"In
+        app","slug":"in_app","enabled":true},{"label":"Mobile push","slug":"mobile_push","enabled":true},{"label":"Web
+        push","slug":"web_push","enabled":true},{"label":"Email","slug":"email","enabled":true}]},{"label":"Upcoming
+        Pending Task","slug":"UpcomingPendingTask","channels":[{"label":"In app","slug":"in_app","enabled":true},{"label":"Mobile
+        push","slug":"mobile_push","enabled":true},{"label":"Web push","slug":"web_push","enabled":true},{"label":"Email","slug":"email","enabled":true}]}]}}'
+  recorded_at: Fri, 14 Feb 2025 00:50:09 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
Add two new methods for Magicbell::Rails
- fetch_categories: fetches all Magicbell categories
- update_notification_preferences: updates the users notification preferences given a payload
both require external_id