### PR TITLE
add require 'magicbell' to magicbell-rails.rb

### DIFF
--- a/lib/magicbell-rails.rb
+++ b/lib/magicbell-rails.rb
@@ -1,4 +1,5 @@
 require 'magicbell/rails/engine' # rubocop:disable Naming/FileName
+require 'magicbell'
 
 module Magicbell
   module Rails

--- a/magicbell-rails.gemspec
+++ b/magicbell-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'magicbell-rails'
-  spec.version     = '0.3.0'
+  spec.version     = '0.3.1'
   spec.authors     = ['Grant Petersen-Speelman', 'Connor Moot']
   spec.email       = ['grant@nexl.io', 'connor@nexl.io']
   spec.homepage    = 'https://github.com/NEXL-LTS/nexl360/local_gems/magicbell-rails'

--- a/spec/magicbell-rails_spec.rb
+++ b/spec/magicbell-rails_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper' # rubocop:disable Naming/FileName
-require 'magicbell'
 
 module Magicbell
   module Rails


### PR DESCRIPTION
When running this from nexl360:
`Magicbell::Rails.fetch_categories(external_id:)`

I get the following error:
`uninitialized constant Magicbell::Rails::MagicBell (NameError)`

This is because 'magicbell' wasn't required in the class. This didn't get picked up on in the specs because we require it in the spec/config so no error was getting thrown.
