### PR TITLE
add create and user_exists? to new User module

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ Magicbell::Rails.bell(
 ```ruby
 # Gets all categories that have been created
 Magicbell::Rails.fetch_categories(external_id:)
+```
 
+```ruby
 # Updates notification preferences given a payload
 payload = { 'notification_preferences' => {
               'categories' => [
@@ -77,6 +79,16 @@ payload = { 'notification_preferences' => {
             }
           }.to_json
 Magicbell::Rails.update_notification_preferences(external_id:, payload:)
+```
+
+```ruby
+# Returns true if the users exists
+Magicbell::Rails.user_exists?(external_id:)
+```
+
+```ruby
+# Creates a user
+Magicbell::Rails.create_user(external_id:, email:, first_name:, last_name:, phone_numbers:)
 ```
 
 ## Contributing

--- a/app/models/magicbell/rails/user.rb
+++ b/app/models/magicbell/rails/user.rb
@@ -1,0 +1,26 @@
+module Magicbell
+  module Rails
+    module User
+      def self.exists?(external_id:)
+        Magicbell::Rails.client.user_with_external_id(external_id).notification_preferences.retrieve
+        true
+      rescue MagicBell::Client::HTTPError
+        false
+      end
+
+      def self.create(external_id:, email:, first_name:, last_name:, phone_numbers: [])
+        payload = {
+          user: { external_id:, email:, first_name:, last_name:, custom_attributes: {}, phone_numbers: }
+        }
+
+        begin
+          response = Magicbell::Rails.client.post('https://api.magicbell.com/users', body: payload.to_json)
+
+          JSON.parse(response.body)['user']
+        rescue MagicBell::Client::HTTPError
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/magicbell-rails.rb
+++ b/lib/magicbell-rails.rb
@@ -18,7 +18,15 @@ module Magicbell
     end
 
     def self.update_notification_preferences(external_id:, payload:)
-      NotificationPreference.update(external_id:, payload: payload)
+      NotificationPreference.update(external_id:, payload:)
+    end
+
+    def self.user_exists?(external_id:)
+      User.exists?(external_id:)
+    end
+
+    def self.create_user(external_id:, email:, first_name:, last_name:, phone_numbers: [])
+      User.create(external_id:, email:, first_name:, last_name:, phone_numbers:)
     end
 
     def self.client

--- a/magicbell-rails.gemspec
+++ b/magicbell-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'magicbell-rails'
-  spec.version     = '0.3.2'
+  spec.version     = '0.4.0'
   spec.authors     = ['Grant Petersen-Speelman', 'Connor Moot']
   spec.email       = ['grant@nexl.io', 'connor@nexl.io']
   spec.homepage    = 'https://github.com/NEXL-LTS/nexl360/local_gems/magicbell-rails'

--- a/magicbell-rails.gemspec
+++ b/magicbell-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'magicbell-rails'
-  spec.version     = '0.3.1'
+  spec.version     = '0.3.2'
   spec.authors     = ['Grant Petersen-Speelman', 'Connor Moot']
   spec.email       = ['grant@nexl.io', 'connor@nexl.io']
   spec.homepage    = 'https://github.com/NEXL-LTS/nexl360/local_gems/magicbell-rails'

--- a/spec/magicbell-rails_spec.rb
+++ b/spec/magicbell-rails_spec.rb
@@ -84,6 +84,65 @@ module Magicbell
           end
         end
       end
+
+      describe '#user_exists?' do
+        let(:external_id) { 'nexl-360-latest.nexl.cloud/455' }
+
+        it 'returns true if the user exists' do
+          VCR.use_cassette('user_exists') do
+            expect(described_class.user_exists?(external_id: external_id)).to be(true)
+          end
+        end
+
+        it 'returns false if the user does not exist' do
+          VCR.use_cassette('user_does_not_exist') do
+            expect(described_class.user_exists?(external_id: 'non-existent-external-id')).to be(false)
+          end
+        end
+      end
+
+      describe '#create_user' do
+        let(:external_id) { 'nexl-360-latest.nexl.cloud/99999' }
+        let(:email) { 'testingcreate@nexl.cloud' }
+        let(:first_name) { 'Test' }
+        let(:last_name) { 'User' }
+        let(:phone_numbers) { [] }
+
+        it 'creates a user on MagicBell' do
+          VCR.use_cassette('create_user') do
+            result = described_class.create_user(
+              external_id:, email:, first_name:, last_name:, phone_numbers:
+            )
+
+            expect(result['id']).to be_present
+          end
+        end
+
+        context 'when the user already exists' do
+          it 'returns true' do
+            VCR.use_cassette('create_existing_user') do
+              result = described_class.create_user(
+                external_id:, email:, first_name:, last_name:, phone_numbers:
+              )
+
+              expect(result['id']).to be_present
+            end
+          end
+        end
+
+        context 'when the user creation fails' do
+          it 'returns false' do
+            VCR.use_cassette('create_user_failure') do
+              expect(
+                described_class.create_user(
+                  external_id:, email: '@invalid@email@.com.com.com', first_name:, last_name:,
+                  phone_numbers:
+                )
+              ).to be(false)
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/vcr_cassettes/create_existing_user.yml
+++ b/spec/vcr_cassettes/create_existing_user.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.magicbell.com/users
+    body:
+      encoding: UTF-8
+      string: '{"user":{"external_id":"nexl-360-latest.nexl.cloud/99999","email":"testingcreate@nexl.cloud","first_name":"Test","last_name":"User","custom_attributes":{},"phone_numbers":[]}}'
+    headers:
+      X-Magicbell-Api-Key:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      X-Magicbell-Api-Secret:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 25 Feb 2025 00:56:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '219'
+      Connection:
+      - keep-alive
+      X-Amzn-Remapped-Date:
+      - Tue, 25 Feb 2025 00:56:18 GMT
+      X-Amzn-Requestid:
+      - 492c63bc-f548-480e-b7f1-6386f5df3c49
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Runtime:
+      - '0.044042'
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Frame-Options:
+      - SAMEORIGIN
+      Access-Control-Allow-Headers:
+      - "*"
+      X-Amzn-Remapped-Content-Length:
+      - '219'
+      X-Download-Options:
+      - noopen
+      X-Request-Id:
+      - d99fe2b1-53b6-49b3-9538-faa9ce37ed0a
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"320df35c7cfe1b02c84dd766010a1139"
+      Access-Control-Allow-Methods:
+      - "*"
+      X-Amzn-Trace-Id:
+      - Root=1-67bd1532-24df16f307b360df55d07be5;Parent=4837daa07b884aed;Sampled=0;Lineage=1:a1dcffa6:0
+      Access-Control-Max-Age:
+      - '86400'
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 490b2d87256587a734fcd39d5d6c7392.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SYD3-P1
+      X-Amz-Cf-Id:
+      - t8gLyt2_HccEdlyQez-v8w_UlM85pPDSAOZvS_TY2Te6rSF7EMzKBQ==
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9173bc151cef57d5-SYD
+    body:
+      encoding: UTF-8
+      string: '{"user":{"id":"1ecd4ec4-9ee5-4c54-908d-56fb7dfbdb13","external_id":"nexl-360-latest.nexl.cloud/99999","email":"testingcreate@nexl.cloud","first_name":"Test","last_name":"User","custom_attributes":{},"phone_numbers":[]}}'
+  recorded_at: Tue, 25 Feb 2025 00:56:18 GMT
+recorded_with: VCR 6.3.1

--- a/spec/vcr_cassettes/create_user.yml
+++ b/spec/vcr_cassettes/create_user.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.magicbell.com/users
+    body:
+      encoding: UTF-8
+      string: '{"user":{"external_id":"nexl-360-latest.nexl.cloud/99999","email":"testingcreate@nexl.cloud","first_name":"Test","last_name":"User","custom_attributes":{},"phone_numbers":[]}}'
+    headers:
+      X-Magicbell-Api-Key:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      X-Magicbell-Api-Secret:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 25 Feb 2025 00:55:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '219'
+      Connection:
+      - keep-alive
+      X-Amzn-Remapped-Date:
+      - Tue, 25 Feb 2025 00:55:55 GMT
+      X-Amzn-Requestid:
+      - 4b537a10-f2f3-4e14-b13d-4f4e789d4a97
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Runtime:
+      - '0.195582'
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Frame-Options:
+      - SAMEORIGIN
+      Access-Control-Allow-Headers:
+      - "*"
+      X-Amzn-Remapped-Content-Length:
+      - '219'
+      X-Download-Options:
+      - noopen
+      X-Request-Id:
+      - c9ecef71-7735-4f37-a94f-1ec5b16698d9
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"320df35c7cfe1b02c84dd766010a1139"
+      Access-Control-Allow-Methods:
+      - "*"
+      X-Amzn-Trace-Id:
+      - Root=1-67bd151b-6a01f33c48f52aa07b1d2ded;Parent=3ae2cf29b48c4df0;Sampled=0;Lineage=1:a1dcffa6:0
+      Access-Control-Max-Age:
+      - '86400'
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 03b68196a4924b2e14289edfecca0cae.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SYD3-P1
+      X-Amz-Cf-Id:
+      - hT4hJvj5rG0-VG3OBXGQnQnmzeijKvSdIuJUCZIp81cdFHQBha5frQ==
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9173bb8afa0ae7c0-SYD
+    body:
+      encoding: UTF-8
+      string: '{"user":{"id":"1ecd4ec4-9ee5-4c54-908d-56fb7dfbdb13","external_id":"nexl-360-latest.nexl.cloud/99999","email":"testingcreate@nexl.cloud","first_name":"Test","last_name":"User","custom_attributes":{},"phone_numbers":[]}}'
+  recorded_at: Tue, 25 Feb 2025 00:55:55 GMT
+recorded_with: VCR 6.3.1

--- a/spec/vcr_cassettes/create_user_failure.yml
+++ b/spec/vcr_cassettes/create_user_failure.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.magicbell.com/users
+    body:
+      encoding: UTF-8
+      string: '{"user":{"external_id":"nexl-360-latest.nexl.cloud/99999","email":"@invalid@email@.com.com.com","first_name":"Test","last_name":"User","custom_attributes":{},"phone_numbers":[]}}'
+    headers:
+      X-Magicbell-Api-Key:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      X-Magicbell-Api-Secret:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Date:
+      - Tue, 25 Feb 2025 01:14:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '70'
+      Connection:
+      - keep-alive
+      X-Amzn-Remapped-Date:
+      - Tue, 25 Feb 2025 01:14:53 GMT
+      X-Amzn-Requestid:
+      - 34cad98a-ad67-4d9e-aaf0-ce72c9e38385
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Runtime:
+      - '0.006526'
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Frame-Options:
+      - SAMEORIGIN
+      Access-Control-Allow-Headers:
+      - "*"
+      X-Download-Options:
+      - noopen
+      X-Request-Id:
+      - f6fa986d-adbe-4d63-af3a-77665451efa7
+      Cache-Control:
+      - no-cache
+      X-Content-Type-Options:
+      - nosniff
+      Access-Control-Allow-Methods:
+      - "*"
+      X-Amzn-Trace-Id:
+      - Root=1-67bd198d-55c893957358e58a694e3657;Parent=56be73541236c8f1;Sampled=0;Lineage=1:a1dcffa6:0
+      Access-Control-Max-Age:
+      - '86400'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 fda8cdb1c5d1bc3e2d4cabe818dc8c5e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SYD3-P1
+      X-Amz-Cf-Id:
+      - BlYJxLudhQslKqodTLvYoRvOVUyEeN8CgV9fgoLkyOyv-R1IQyS4Ew==
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9173d7512cb25d31-SYD
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"message":"Param ''user.email'' must be an email address"}]}'
+  recorded_at: Tue, 25 Feb 2025 01:14:53 GMT
+recorded_with: VCR 6.3.1

--- a/spec/vcr_cassettes/user_does_not_exist.yml
+++ b/spec/vcr_cassettes/user_does_not_exist.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.magicbell.io/notification_preferences
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Magicbell-Api-Key:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      X-Magicbell-Api-Secret:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      X-Magicbell-User-External-Id:
+      - non-existent-external-id
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Tue, 25 Feb 2025 00:50:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '261'
+      Connection:
+      - keep-alive
+      Access-Control-Max-Age:
+      - '86400'
+      X-Amzn-Requestid:
+      - b191d942-8238-419b-94e5-d8ed101336bf
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      X-Amzn-Trace-Id:
+      - Root=1-67bd13d6-2996abd2246c03ea0f546f72;Parent=6e21b4ba5502aa78;Sampled=0;Lineage=1:a1dcffa6:0
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 fda8cdb1c5d1bc3e2d4cabe818dc8c5e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SYD3-P1
+      X-Amz-Cf-Id:
+      - j88KFA-uJy2siETuEwYPCJsp_4Kun_erpA_KCm8AVL6eKwi9g9YHWw==
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=t2cWYHnrvXKtS5uhSgGDot39OvmBKUlwnF0HpRkyigt6zERIpAnyWfn5xANX8JbxsJ3b3Y6ZEfgwg8%2BvwJ%2FKUDFJk%2FmFFPTlbzJyuX8HdzZ5WvvcvDg940GktCD6DG34jss%3D"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9173b39d8df75727-SYD
+      Server-Timing:
+      - cfL4;desc="?proto=TCP&rtt=7825&min_rtt=7162&rtt_var=4013&sent=4&recv=6&lost=0&retrans=0&sent_bytes=2796&recv_bytes=998&delivery_rate=232218&cwnd=233&unsent_bytes=0&cid=be3da222a978f6cd&ts=323&x=0"
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":"user_not_found","message":"User not found","suggestion":"Please
+        provide the correct ''X-MAGICBELL-USER-EMAIL'' or ''X-MAGICBELL-USER-EXTERNAL-ID''
+        header to identify the user.","help_link":"https://magicbell.com/docs/rest-api/authentication"}]}
+
+        '
+  recorded_at: Tue, 25 Feb 2025 00:50:30 GMT
+recorded_with: VCR 6.3.1

--- a/spec/vcr_cassettes/user_exists.yml
+++ b/spec/vcr_cassettes/user_exists.yml
@@ -1,0 +1,107 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.magicbell.io/notification_preferences
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Magicbell-Api-Key:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      X-Magicbell-Api-Secret:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      X-Magicbell-User-External-Id:
+      - nexl-360-latest.nexl.cloud/455
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 25 Feb 2025 00:50:30 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Amzn-Trace-Id:
+      - Root=1-67bd13d6-7db213c749a1895017c2205c;Parent=217383ede9171ced;Sampled=0;Lineage=1:a1dcffa6:0
+      Access-Control-Max-Age:
+      - '86400'
+      X-Amzn-Requestid:
+      - 14351a78-5144-4977-82c4-50c5872517ac
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Vary:
+      - accept-encoding
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 aebce22763fb7e32a807cd494884a9b4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SYD3-P1
+      X-Amz-Cf-Id:
+      - jy2fiNqPjRpa0nRSsb4ZVIzCY4LK0JO-eLJ3ypI8H37RYuSLzz61qA==
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=jHTrxaUgjzm5b7MnclxnScyvX5wjulnw5WMybMtK2yy3OlRjvrgS%2BtXcixlBBggZgraeuNr6PtzeHq2PFrzZoxEvt1gbvzvhZ0RHWU47l8Va9uSRxL%2BbCM4YxwAlnqeGueM%3D"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9173b3977f05a95b-SYD
+      Server-Timing:
+      - cfL4;desc="?proto=TCP&rtt=24913&min_rtt=10105&rtt_var=13621&sent=5&recv=6&lost=0&retrans=0&sent_bytes=2795&recv_bytes=1004&delivery_rate=286590&cwnd=251&unsent_bytes=0&cid=58181857efb300f4&ts=940&x=0"
+    body:
+      encoding: ASCII-8BIT
+      string: '{"notification_preferences":{"categories":[{"slug":"StayInTouchReminder","label":"Stay
+        in Touch","channels":[{"slug":"in_app","label":"In App","enabled":true},{"slug":"mobile_push","label":"Mobile
+        Push","enabled":true},{"slug":"web_push","label":"Web Push","enabled":true},{"slug":"email","label":"Email","enabled":false},{"slug":"slack","label":"Slack","enabled":true},{"slug":"sms","label":"Sms","enabled":true}]},{"slug":"DelegatedTaskReopened","label":"Delegated
+        Task Reopened","channels":[{"slug":"in_app","label":"In App","enabled":true},{"slug":"mobile_push","label":"Mobile
+        Push","enabled":true},{"slug":"web_push","label":"Web Push","enabled":true},{"slug":"email","label":"Email","enabled":false},{"slug":"slack","label":"Slack","enabled":true},{"slug":"sms","label":"Sms","enabled":true}]},{"slug":"FollowUpReminder","label":"Opportunity
+        Follow Up Reminder","channels":[{"slug":"in_app","label":"In App","enabled":true},{"slug":"mobile_push","label":"Mobile
+        Push","enabled":true},{"slug":"web_push","label":"Web Push","enabled":true},{"slug":"email","label":"Email","enabled":false},{"slug":"slack","label":"Slack","enabled":true},{"slug":"sms","label":"Sms","enabled":true}]},{"slug":"CreateActivityReminder","label":"Create
+        Activity Reminder","channels":[{"slug":"in_app","label":"In App","enabled":true},{"slug":"mobile_push","label":"Mobile
+        Push","enabled":true},{"slug":"web_push","label":"Web Push","enabled":true},{"slug":"email","label":"Email","enabled":false},{"slug":"slack","label":"Slack","enabled":true},{"slug":"sms","label":"Sms","enabled":true}]},{"slug":"UpcomingMeetingReminder","label":"Upcoming
+        Meeting Reminder","channels":[{"slug":"in_app","label":"In App","enabled":true},{"slug":"mobile_push","label":"Mobile
+        Push","enabled":true},{"slug":"web_push","label":"Web Push","enabled":true},{"slug":"email","label":"Email","enabled":false},{"slug":"slack","label":"Slack","enabled":true},{"slug":"sms","label":"Sms","enabled":true}]},{"slug":"UpcomingPendingTask","label":"Upcoming
+        Pending Task","channels":[{"slug":"in_app","label":"In App","enabled":true},{"slug":"mobile_push","label":"Mobile
+        Push","enabled":true},{"slug":"web_push","label":"Web Push","enabled":true},{"slug":"email","label":"Email","enabled":false},{"slug":"slack","label":"Slack","enabled":true},{"slug":"sms","label":"Sms","enabled":true}]},{"slug":"AssignedTask","label":"Task
+        Assigned","channels":[{"slug":"in_app","label":"In App","enabled":true},{"slug":"mobile_push","label":"Mobile
+        Push","enabled":true},{"slug":"web_push","label":"Web Push","enabled":true},{"slug":"email","label":"Email","enabled":false},{"slug":"slack","label":"Slack","enabled":true},{"slug":"sms","label":"Sms","enabled":true}]},{"slug":"OpportunityStatusChanged","label":"Opportunity
+        Status Updated","channels":[{"slug":"in_app","label":"In App","enabled":true},{"slug":"mobile_push","label":"Mobile
+        Push","enabled":true},{"slug":"web_push","label":"Web Push","enabled":true},{"slug":"email","label":"Email","enabled":false},{"slug":"slack","label":"Slack","enabled":true},{"slug":"sms","label":"Sms","enabled":true}]},{"slug":"DelegatedTaskCompleted","label":"Delegated
+        Task Completed","channels":[{"slug":"in_app","label":"In App","enabled":true},{"slug":"mobile_push","label":"Mobile
+        Push","enabled":true},{"slug":"web_push","label":"Web Push","enabled":true},{"slug":"email","label":"Email","enabled":false},{"slug":"slack","label":"Slack","enabled":true},{"slug":"sms","label":"Sms","enabled":true}]},{"slug":"ListShared","label":"List
+        Shared","channels":[{"slug":"in_app","label":"In App","enabled":true},{"slug":"mobile_push","label":"Mobile
+        Push","enabled":true},{"slug":"web_push","label":"Web Push","enabled":true},{"slug":"email","label":"Email","enabled":false},{"slug":"slack","label":"Slack","enabled":true},{"slug":"sms","label":"Sms","enabled":true}]},{"slug":"StayInTouchBatchedReminder","label":"Stay
+        In Touch Batched Reminder","channels":[{"slug":"in_app","label":"In App","enabled":true},{"slug":"mobile_push","label":"Mobile
+        Push","enabled":true},{"slug":"web_push","label":"Web Push","enabled":true},{"slug":"email","label":"Email","enabled":false},{"slug":"slack","label":"Slack","enabled":true},{"slug":"sms","label":"Sms","enabled":true}]},{"slug":"CommentAdded","label":"Comment
+        Added","channels":[{"slug":"in_app","label":"In App","enabled":true},{"slug":"mobile_push","label":"Mobile
+        Push","enabled":true},{"slug":"web_push","label":"Web Push","enabled":true},{"slug":"email","label":"Email","enabled":false},{"slug":"slack","label":"Slack","enabled":true},{"slug":"sms","label":"Sms","enabled":true}]},{"slug":"CommentMentioned","label":"Comment
+        Mentioned","channels":[{"slug":"in_app","label":"In App","enabled":true},{"slug":"mobile_push","label":"Mobile
+        Push","enabled":true},{"slug":"web_push","label":"Web Push","enabled":true},{"slug":"email","label":"Email","enabled":false},{"slug":"slack","label":"Slack","enabled":true},{"slug":"sms","label":"Sms","enabled":true}]},{"slug":"NewProjectMembership","label":"New
+        Workspace Membership","channels":[{"slug":"in_app","label":"In App","enabled":true},{"slug":"mobile_push","label":"Mobile
+        Push","enabled":true},{"slug":"web_push","label":"Web Push","enabled":true},{"slug":"email","label":"Email","enabled":false},{"slug":"slack","label":"Slack","enabled":true},{"slug":"sms","label":"Sms","enabled":true}]},{"slug":"SharedListView","label":"List
+        View Shared","channels":[{"slug":"in_app","label":"In App","enabled":true},{"slug":"mobile_push","label":"Mobile
+        Push","enabled":true},{"slug":"web_push","label":"Web Push","enabled":true},{"slug":"email","label":"Email","enabled":false},{"slug":"slack","label":"Slack","enabled":true},{"slug":"sms","label":"Sms","enabled":true}]}]}}
+
+        '
+  recorded_at: Tue, 25 Feb 2025 00:50:30 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
### Summary
We need to check if a user exists before fetching their categories. If we don't do this we end up with a `MagicBell::Client::HTTPError` because the external_id we searched for doesn't exist. We also need to add a create in the case that the user doesn't exist and we need to create one in MagicBell ourselves.

### Changes
- Added `User.create`
- Added `User.exists?` (I had to use .notification_preferences.retrieve because magicbell does not have an endpoint for looking up user by external_id or email)
- Updated version from `0.3.1` -> `0.4.0`